### PR TITLE
Fix invalid nullptr dereference in TagSection.keys()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-apt (2.8.0deepin2) unstable; urgency=medium
+
+  * Fix invalid nullptr dereference in TagSection.keys() [CVE-2025-6966]
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Tue, 03 Feb 2026 20:14:47 +0800
+
 python-apt (2.8.0deepin1) unstable; urgency=medium
 
   * Fix FTBFS with Sphinx 8.0

--- a/python/tag.cc
+++ b/python/tag.cc
@@ -280,8 +280,10 @@ static PyObject *TagSecKeys(PyObject *Self,PyObject *Args)
       const char *End = Start;
       for (; End < Stop && *End != ':'; End++);
 
-      PyObject *Obj;
-      PyList_Append(List,Obj = PyString_FromStringAndSize(Start,End-Start));
+      PyObject *Obj = PyString_FromStringAndSize(Start, End-Start);
+      if (Obj == nullptr)
+          return Py_DECREF(List), nullptr;
+      PyList_Append(List, Obj);
       Py_DECREF(Obj);
    }
    return List;

--- a/tests/test_tagfile.py
+++ b/tests/test_tagfile.py
@@ -135,6 +135,11 @@ class TestTagSection(testcommon.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
 
+    def test_invalid_unicode_key(self):
+        ts = apt_pkg.TagSection(b"T\xc3st: Value\n", bytes=True)
+        self.assertEqual(len(ts), 1)
+        self.assertRaises(UnicodeDecodeError, ts.keys)
+
     def test_write(self):
         ts = apt_pkg.TagSection("a: 1\nb: 2\nc: 3\n")
         outpath = os.path.join(self.temp_dir, "test")


### PR DESCRIPTION
If a key is not valid UTF-8, PyString_FromStringAndSize() returned
nullptr, which we subsequently passed to PyList_Append() and
Py_DECREF(), the latter trying to dereference it and causing a
segmentation fault.

LP: #2091865
